### PR TITLE
Added a listener for the 'error' event on the queryStream

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -36,8 +36,8 @@ class App {
             await command.invoke(args.splice(1));
         }
 
-        this.logger.info(`Proccess Id: ${process.pid}`);
-        this.logger.info('Waiting for sqs schedule event');
+        this.logger.silly(`Proccess Id: ${process.pid}`);
+        this.logger.silly('Waiting for schedule event');
         while (!shutdownRequested) {
             await sleep(1000);
 

--- a/source/DataAccess/Oracle/OracleReader.ts
+++ b/source/DataAccess/Oracle/OracleReader.ts
@@ -47,6 +47,11 @@ export default class OracleReader implements IDataReader {
             const queryResultStream = await this._connection.queryStream(queryStatement, [],
                 { outFormat: oracledb.OBJECT, fetchArraySize: 10000, extendedMetaData: true } as any);
 
+            // Must handle errors to gracefully react otherwise the process may become unstable
+            queryResultStream.on('error', (error) => {
+                    this._logger.error(`Failed to execute: '${queryStatement}' - ${error.stack}`);
+            });
+
             const metadataStream = await this.getMetadata(queryResultStream);
 
             const jsonTransformer = new stream.Transform( { objectMode: true });


### PR DESCRIPTION
This could be expanded on further down the road but right now it will at least give us back the error and the exact query it failed to execute (in case of long running queries). This has a nice side effect of debug sessions continuing to run even when a query fails. 