### PR TITLE
feature/data-delimiter

### DIFF
--- a/source/DataAccess/Oracle/OracleReader.ts
+++ b/source/DataAccess/Oracle/OracleReader.ts
@@ -114,7 +114,7 @@ export default class OracleReader implements IDataReader {
         const jsonTransformer = new stream.Transform( { objectMode: true });
         jsonTransformer._transform = function (chunk, encoding, done) {
             // TODO: Decide on a format/encoding/structure - JSON for now
-            const data = JSON.stringify(chunk);
+            const data = JSON.stringify(chunk) + '\n';
             this.push(Buffer.from(data, encoding));
             done();
         };

--- a/source/IntegrationConfigFactory.ts
+++ b/source/IntegrationConfigFactory.ts
@@ -451,7 +451,7 @@ export default class IntegrationConfigFactory {
                     query: 'Select * from SSRMEET'
                 });
                 BANNER_TEMPLATE_STATEMENTS.push({
-                    name: 'SSRXLST',
+                    name: 'SSRXLST',        
                     query: 'Select * from SSRXLST'
                 });
                 BANNER_TEMPLATE_STATEMENTS.push({
@@ -564,7 +564,7 @@ export default class IntegrationConfigFactory {
                     'SELECT 2 as "priority", u.table_name, DBMS_METADATA.GET_DDL(\'INDEX\',u.index_name) as ddl ' +
                     'FROM USER_INDEXES u ' +
                     `WHERE u.table_name in (${tableFilter})`  +
-                    'ORDER BY "priority", table_name';
+                    'ORDER BY table_name, "priority"';
 
                 BANNER_TEMPLATE_STATEMENTS.push({
                     name: `ddl`,


### PR DESCRIPTION
The indivdual records are json encoded but do not reside in a parent document so reading is a bit difficult. Adding in a new line as the delimiter should ease the pain and possibly open things up to be more easily streamed.