### PR TITLE
Upping the bitbucket pipeline memory for docker 

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -52,3 +52,7 @@ pipelines:
 
             # Run system test
             - . ./pipeline/run-system-tests.sh
+definitions:
+  services:
+    docker:
+      memory: 2048 


### PR DESCRIPTION
...to 2GB since the default 1GB doesn't seem to suffice