### PR TITLE
Corrected casing for ALL_TABLES query for the demo integration

### DIFF
--- a/source/IntegrationConfigFactory.ts
+++ b/source/IntegrationConfigFactory.ts
@@ -595,7 +595,7 @@ export default class IntegrationConfigFactory {
                 const DEMO_TEMPLATE_STATEMENTS: IQueryDefinition[] = new Array<IQueryDefinition>();
 
                 DEMO_TEMPLATE_STATEMENTS.push({
-                    name: 'all_tables',
+                    name: 'ALL_TABLES',
                     query: 'SELECT * FROM ALL_TABLES'
                 });
                 return {


### PR DESCRIPTION
The DDL fetch on ALL_TABLES fails because the GET_DDL function is case sensitive