### PR TITLE
Cache download of oracle-instantclient

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:8-slim AS build-env
 ENV CLIENT_FILENAME instantclient-basiclite-linux.x64-18.3.0.0.0dbru.zip
 WORKDIR /app
 ADD . .
-ADD https://github.com/adastradev/oracle-instantclient/raw/master/${CLIENT_FILENAME} .
+RUN wget -q https://github.com/adastradev/oracle-instantclient/raw/master/${CLIENT_FILENAME}
 RUN node --version && \
     apt-get update && apt-get install libaio1 unzip && \
     mv /app/${CLIENT_FILENAME} /usr/lib && \


### PR DESCRIPTION
Avoid repeatedly downloading the oracle-instantclient zip file every time the build is run.  This can be done so long as the version number of the file is incremented during updates.