### PR TITLE
Use adastradev/oracle-instantclient Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 .git
-dist
+dist/
 node_modules/
 .nyc_output/
 coverage/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,50 +1,45 @@
-# run unit tests first against the same base image
-FROM node:8-slim AS base-env
-ARG CLIENT_FILENAME=instantclient-basiclite-linux.x64-18.3.0.0.0dbru.zip
-WORKDIR /app
-ADD . .
-RUN node --version
-RUN apt-get update && apt-get install libaio1 unzip
-WORKDIR /usr/lib
-RUN wget -q https://github.com/adastradev/oracle-instantclient/raw/master/${CLIENT_FILENAME}
-RUN unzip ${CLIENT_FILENAME} && rm ${CLIENT_FILENAME}
-RUN apt-get -y remove unzip && apt-get clean
-
 # compile image intended for building and testing
 FROM node:8-slim AS build-env
-ENV LD_LIBRARY_PATH /usr/lib/instantclient_18_3
+ENV LD_LIBRARY_PATH /usr/lib/oracle/18.3/client64/lib
 ARG INTEGRATION_TESTS_ENABLED=false
-ARG ORACLE_ENDPOINT=
-ARG ORACLE_USER=
-ARG ORACLE_PASSWORD=
+ARG ORACLE_ENDPOINT
+ARG ORACLE_USER
+ARG ORACLE_PASSWORD
 ARG COVERALLS_REPO_TOKEN=false
-ARG COVERALLS_GIT_COMMIT=
-ARG COVERALLS_GIT_BRANCH=
-WORKDIR /app
-COPY --from=base-env /app .
-COPY --from=base-env /usr/lib /usr/lib
-COPY --from=base-env /lib /lib
+ARG COVERALLS_GIT_COMMIT
+ARG COVERALLS_GIT_BRANCH
+
 RUN apt-get update && apt-get -y install git-core
-RUN npm install
-RUN npm run build
-RUN npm run test
-RUN if [ "$COVERALLS_REPO_TOKEN" = "false" ] ; then echo "Coveralls reporting disabled" ; else npm run coveralls ; fi
-RUN if [ "$INTEGRATION_TESTS_ENABLED" = "true" ] ; then npm run integration-test ; else echo Integration tests disabled ; fi
-RUN apt-get -y remove git-core && apt-get clean
+
+WORKDIR /app
+COPY --from=adastradev/oracle-instantclient:18.3-lite /usr/lib/oracle /usr/lib/oracle
+COPY --from=adastradev/oracle-instantclient:18.3-lite /usr/lib64/libaio* /lib/
+COPY package.json package-lock.json *.ts *config* ./
+COPY source ./source
+COPY test ./test
+COPY docs ./docs
+
+RUN npm ci &&\
+    npm run build &&\
+    npm run test &&\
+    if [ "$COVERALLS_REPO_TOKEN" = "false" ] ; then echo "Coveralls reporting disabled" ; else npm run coveralls ; fi &&\
+    if [ "$INTEGRATION_TESTS_ENABLED" = "true" ] ; then npm run integration-test ; else echo Integration tests disabled ; fi
+RUN rm -rf node_modules dist/test &&\
+    npm ci --production &&\
+    apt-get -y remove git-core && apt-get clean
 
 # compile image intended for production use
 FROM node:8-slim AS prod-env
-ENV LD_LIBRARY_PATH /usr/lib/instantclient_18_3
+ENV LD_LIBRARY_PATH /usr/lib/oracle/18.3/client64/lib
 ENV LOG_PATH /var/log/dia
 RUN mkdir /var/log/dia
 WORKDIR /app
-COPY --from=base-env /app .
-COPY --from=base-env /usr/lib /usr/lib
-COPY --from=base-env /lib /lib
-COPY --from=build-env /app/dist /app/dist
-RUN apt-get update && apt-get -y install git-core && \
-    npm install --production && \
-    apt-get -y remove git-core && apt-get -y autoremove && apt-get clean
+COPY --from=adastradev/oracle-instantclient:18.3-lite /usr/lib/oracle /usr/lib/oracle
+COPY --from=adastradev/oracle-instantclient:18.3-lite /usr/lib64/libaio* /lib/
+COPY --from=build-env /app/package.json .
+COPY --from=build-env /app/dist dist
+COPY --from=build-env /app/docs docs
+COPY --from=build-env /app/node_modules node_modules
 
 # Report to docker the health status so we can possibly use that information
 # For now mark unhealthy after 25 sec (interval*retries)

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
+    "build:dev": "tsc --sourceMap true",
     "test": "nyc --require ts-node/register mocha --timeout 999999 test/unit/**/*.spec.ts",
     "integration-test": "nyc --require ts-node/register mocha --timeout 999999 test/integration/**/*.spec.ts",
     "system-test": "mocha -r ts-node/register --timeout 999999 test/system/**/*.spec.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "sourceMap": true,
     "forceConsistentCasingInFileNames": true,
     "noImplicitReturns": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
Consumes the adastradev/oracle-instantclient image, uses fewer apt-get calls, and deploys fewer files in the final image.